### PR TITLE
Encrypted fields should not assume None is an allowed value

### DIFF
--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -54,7 +54,7 @@ class EncryptedFieldMixin(object):
             if not isinstance(value, str):
                 value = str(value)
             return self.f.encrypt(bytes(value, "utf-8")).decode("utf-8")
-        return None
+        return ""
 
     def get_db_prep_value(self, value, connection, prepared=False):
         if not prepared:


### PR DESCRIPTION
Since all of the encrypted fields, no matter what the underlying data type is, are always stored as `TextField`,  we should return an empty string rather than `None`, to allow an empty string to be stored in the field.

We came across an issue where, when using [Django Solo](https://github.com/lazybird/django-solo/), if a singleton model instance did not exist, Solo would try and create one, but could not because one of the fields was not nullable.