### PR TITLE
Added ability to use Django's SECRET_KEY_FALLBACKS to rotate secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,18 @@ SALT_KEY = [
 ]
 ```
 
+#### Rotating SECRET_KEY
+
+When you would want to rotate your `SECRET_KEY`, set the new value and put your old secret key value to `SECRET_KEY_FALLBACKS` list. That way the existing encrypted fields will still work, but when you re-save the field or create new record, it will be encrypted with the new secret key. (supported in Django >=4.1)
+
+```python
+SECRET_KEY = "new-key"
+SECRET_KEY_FALLBACKS = ["old-key"]
+```
+
 If you wish to update the existing encrypted records simply load and re-save the models to use the new key.
 
-```
+```python
 for obj in MuModel.objects.all():
     obj.save()
 ```

--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -28,20 +28,22 @@ class EncryptedFieldMixin:
             if isinstance(settings.SALT_KEY, list)
             else [settings.SALT_KEY]
         )
-        for salt_key in salt_keys:
-            salt = bytes(salt_key, "utf-8")
-            kdf = PBKDF2HMAC(
-                algorithm=hashes.SHA256(),
-                length=32,
-                salt=salt,
-                iterations=100000,
-                backend=default_backend(),
-            )
-            keys.append(
-                base64.urlsafe_b64encode(
-                    kdf.derive(settings.SECRET_KEY.encode("utf-8"))
+        secret_keys = [settings.SECRET_KEY] + (settings.SECRET_KEY_FALLBACKS or [])
+        for secret_key in secret_keys:
+            for salt_key in salt_keys:
+                salt = bytes(salt_key, "utf-8")
+                kdf = PBKDF2HMAC(
+                    algorithm=hashes.SHA256(),
+                    length=32,
+                    salt=salt,
+                    iterations=100_000,
+                    backend=default_backend(),
                 )
-            )
+                keys.append(
+                    base64.urlsafe_b64encode(
+                        kdf.derive(secret_key.encode("utf-8"))
+                    )
+                )
         return keys
 
     @cached_property

--- a/encrypted_fields/fields.py
+++ b/encrypted_fields/fields.py
@@ -28,7 +28,7 @@ class EncryptedFieldMixin:
             if isinstance(settings.SALT_KEY, list)
             else [settings.SALT_KEY]
         )
-        secret_keys = [settings.SECRET_KEY] + (settings.SECRET_KEY_FALLBACKS or [])
+        secret_keys = [settings.SECRET_KEY] + getattr(settings, "SECRET_KEY_FALLBACKS", list())
         for secret_key in secret_keys:
             for salt_key in salt_keys:
                 salt = bytes(salt_key, "utf-8")


### PR DESCRIPTION
I implemented use of `SECRET_KEY_FALLBACKS` so when I would want to rotate secret key, I can just add old secret key to `SECRET_KEY_FALLBACKS` and the encrypted fields will work just as before. 

When writing tests, I discovered that there is a problem with `cached_property` on `EncryptedFieldMixin`, becaus it was not being changed by `override_settings`. Solved by invalidating the cached properties in test setup and teardown. 

And I also stumbled upon some other problem with existing `RotatedSaltTestCase` test. Even with the same secret key, salt and field value the result cipher will be different each time. So it does not make sense to compare result ciphers, they will never be the same. 