### PR TITLE
Fix EncryptedBooleanField storing false as null

### DIFF
--- a/package_test/tests.py
+++ b/package_test/tests.py
@@ -195,6 +195,19 @@ class FieldTest(TestCase):
 
         with pytest.raises(ValidationError):
             model.save()
+    
+    def test_encrypted_boolean_field_preserves_true_false_and_none(self) -> None:
+        true_obj = TestModel.objects.create(boolean=True)
+        false_obj = TestModel.objects.create(boolean=False)
+        none_obj = TestModel.objects.create(boolean=None)
+
+        true_obj.refresh_from_db()
+        false_obj.refresh_from_db()
+        none_obj.refresh_from_db()
+
+        assert true_obj.boolean is True
+        assert false_obj.boolean is False
+        assert none_obj.boolean is None
 
     def test_json_field_encrypted(self) -> None:
         dict_values = {

--- a/src/encrypted_fields/fields.py
+++ b/src/encrypted_fields/fields.py
@@ -174,7 +174,11 @@ class EncryptedEmailField(EncryptedFieldMixin, models.EmailField):
 
 
 class EncryptedBooleanField(EncryptedFieldMixin, models.BooleanField):
-    pass
+    def get_prep_value(self, value: _TypeAny) -> _TypeAny:
+        value = models.BooleanField.get_prep_value(self, value)
+        if value is None:
+            return None
+        return self.f.encrypt(str(value).encode("utf-8")).decode("utf-8")
 
 
 class EncryptedJSONField(EncryptedFieldMixin, models.JSONField):


### PR DESCRIPTION
This change fixes a bug in `EncryptedBooleanField` where `False` does not round-trip correctly through the database.

The issue is that `EncryptedBooleanField` inherits `EncryptedFieldMixin.get_prep_value()`, and that shared implementation uses `if value:` before encrypting. That works for truthy values, but it treats `False` as empty and returns `None` instead of encrypting it. The result is that saving `False` writes `NULL`, and reading the record back returns `None` rather than `False`.

Because of that, `EncryptedBooleanField` currently cannot reliably preserve the distinction between `True`, `False`, and `None`. For nullable boolean fields, that is a correctness issue, not just a formatting issue, since `False` and `None` have different meanings.

The added test demonstrates the problem directly. When `EncryptedBooleanField` is implemented as:

```python
class EncryptedBooleanField(EncryptedFieldMixin, models.BooleanField):
    pass
```

this assertion fails after saving and reloading:

```python
assert false_obj.boolean is False
```

That failure shows `False` is being lost during persistence. This fix overrides the boolean prep path so that `False` is encrypted and restored correctly, while `None` continues to map to `NULL`.