### PR TITLE
Fix encrypted field state after validation errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,24 +10,24 @@ Please follow these guidelines to ensure your contributions are accepted:
 
 1. **Fork the Repository**: Start by forking the repository to a personal/organization GitHub account.
 2. **Clone the Repository**: Clone the forked repository to your local machine.
-3. **Set Up the Environment**: Set up a virtual environment and install the necessary
-   dependencies for development and testing.
+3. **Set Up the Environment**: Set up a virtual environment and install the necessary dependencies for development and testing.
    ```shell
    $ python -m venv .venv
    $ source .venv/bin/activate
    $ pip install -r requirements.txt
    ```
-4. **Install the pre-commit hooks**: We use [pre-commit](https://pre-commit.com/) to ensure code quality.
-   Install the pre-commit hooks by running:
+4. **Install the pre-commit hooks**: We use [pre-commit](https://pre-commit.com/) to ensure code quality. Install `pre-commit` and set up the Git hooks by running:
+
    ```shell
    $ pre-commit install
    ```
+
 5. **Create a Branch**: Create a new branch for the feature or bug fix.
 6. **Make Changes**: Make the changes and ensure they are well-documented.
 7. **Run Tests**: Ensure all tests pass before submitting a pull request.
    ```shell
-   $ pip install coverage pytest
-   $ coverage3 run --source='./encrypted_fields' manage.py test
+   $ pip install -e .
+   $ coverage run --source='encrypted_fields' manage.py test
    ```
 8. **Submit Pull Request**: Submit a pull request with a clear title, description of the changes,
    motivations, and any relevant issue numbers.

--- a/package_test/tests.py
+++ b/package_test/tests.py
@@ -48,6 +48,19 @@ class FieldTest(TestCase):
         fresh_model = TestModel.objects.get(id=model.id)
         assert fresh_model.text == plaintext
 
+    def test_validation_error_does_not_break_future_decryption(self) -> None:
+        field = TestModel._meta.get_field("integer")
+
+        with pytest.raises(ValidationError):
+            field.clean(2147483648, None)
+
+        plaintext = 42
+
+        model = TestModel.objects.create(integer=plaintext)
+        fresh_model = TestModel.objects.get(id=model.id)
+
+        assert fresh_model.integer == plaintext
+
     def test_datetime_field_encrypted(self) -> None:
         plaintext = timezone.now()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+coverage
+django
+pre-commit
+pytest

--- a/src/encrypted_fields/fields.py
+++ b/src/encrypted_fields/fields.py
@@ -95,9 +95,11 @@ class EncryptedFieldMixin:
         to decrypt an already decrypted value during cleaning of a form
         """
         self._already_decrypted = True
-        ret = super().clean(value, model_instance)
-        del self._already_decrypted
-        return ret
+
+        try:
+            return super().clean(value, model_instance)
+        finally:
+            del self._already_decrypted
 
 
 class EncryptedCharField(EncryptedFieldMixin, models.CharField):


### PR DESCRIPTION
This fixes an issue where _already_decrypted could remain set on an encrypted field when super().clean() raised a ValidationError.

Since _already_decrypted is used to prevent to_python() from decrypting an already decrypted value during validation, leaving it set caused subsequent values loaded from the database to be returned as ciphertext instead of being decrypted.

The cleanup is now performed in a finally block, ensuring that the temporary state is removed even when validation fails.

A regression test has been added that triggers a validation error and verifies that subsequent encrypted values can still be decrypted correctly.

This PR also includes a small update to the contributing setup:

* adds the development/test requirements
* documents installing the package in editable mode
* updates the coverage command to use the current coverage entry point